### PR TITLE
fix: the dependency version

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021
+Copyright (c) 2023
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# 1.2.5
+
+- Fix: a specific version of ruamel.yaml was used
+
 # 1.2.4
 
 - New utils module.

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     install_requires=[
         'foliant>=1.0.5',
         'jinja2',
-        'ruamel.yaml',
+        'ruamel.yaml==0.17.40',
         'foliantcontrib.utils>=1.0.2',
     ],
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     description=SHORT_DESCRIPTION,
     long_description=LONG_DESCRIPTION,
     long_description_content_type='text/markdown',
-    version='1.2.4',
+    version='1.2.5',
     author='Daniil Minukhin',
     author_email='ddddsa@gmail.com',
     packages=['foliant.preprocessors.swaggerdoc'],


### PR DESCRIPTION
An error occurs when using version `0.18` of the [`ruamel.yaml`](https://pypi.org/project/ruamel.yaml/) package:
```bash
yaml = YAML(typ='unsafe', pure=True)
yaml.dump(...)
instead of file "/usr/local/lib/python3.8/dist-packages/foliant/preprocessors/swaggerdoc/swaggerdoc.py", line 140
                  yaml.dump(environment, f)
```
In this PR, version `0.17.40` is selected for `ruamel.yaml`